### PR TITLE
Change multiplication proof and add P!=Q constraint

### DIFF
--- a/src/commit/mult.ts
+++ b/src/commit/mult.ts
@@ -161,7 +161,7 @@ export async function aggregateMult(
     const A_yrel = new Relation(params.c)
     A_yrel.insertM([params.g, params.h, Cy, pi.A_y.neg()], [pi.t_y, pi.t_ry, cc, params.c.newScalar(BigInt(1))])
     const A_4_2rel = new Relation(params.c)
-    A_4_2rel.insertM([Cx, params.h, Cz.neg(), pi.A_4_2.neg()], [pi.t_y, pi.t_r4, cc, params.c.newScalar(BigInt(1))])
+    A_4_2rel.insertM([Cx, params.h, Cz, pi.A_4_2.neg()], [pi.t_y, pi.t_r4, cc, params.c.newScalar(BigInt(1))])
 
     A_xrel.drain(multi)
     A_yrel.drain(multi)

--- a/src/commit/mult.ts
+++ b/src/commit/mult.ts
@@ -94,7 +94,7 @@ export async function proveMult(
     params: PedersenParams,
     x: bigint,
     y: bigint,
-    z: bigint,
+    _z: bigint,
     Cx: Commitment,
     Cy: Commitment,
     Cz: Commitment

--- a/src/commit/mult.ts
+++ b/src/commit/mult.ts
@@ -100,33 +100,33 @@ export async function proveMult(
     Cz: Commitment
 ): Promise<MultProof> {
     const xx = params.c.newScalar(x),
-    /*C4 = Cy.p.mul(xx), // C4 = Cy * x
-    r4 = Cy.r.mul(xx), // C4 = zG + r4H*/
-    // Step 1: Compute commitments
-    k_x = rnd(params.c.order),
-    k_y = rnd(params.c.order),
-    k_z = rnd(params.c.order),
-    ky = params.c.newScalar(k_y),
-    kz = params.c.newScalar(k_z),
-    Ax = params.commit(k_x),
-    Ay = params.commit(k_y),
-    //Az = params.commit(k_z),
-    //A4_1 = params.commit(k_z),
-    A4_2 = (Cx.p.mul(ky)).add(params.h.mul(kz)),
-    // Step 2: Compute challenge  H(Cx, Cy, Cz, C4, Ax, Ay, Az, A4_1, A4_2)
-    c = await hashPoints('SHA-256', [Cx.p, Cy.p, Cz.p, Ax.p, Ay.p, A4_2]),
-    cc = params.c.newScalar(c),
-    kx = params.c.newScalar(k_x),
-    //kz = params.c.newScalar(k_z),
-    yy = params.c.newScalar(y),
-    //zz = params.c.newScalar(z),
-    t_x = kx.sub(cc.mul(xx)), // tx = kx-c*x
-    t_y = ky.sub(cc.mul(yy)), // ty = ky-c*y
-    //t_z = kz.sub(cc.mul(zz)), // tz = kz-c*z
-    t_rx = Ax.r.sub(cc.mul(Cx.r)), //  t_rx = sx-c*rx
-    t_ry = Ay.r.sub(cc.mul(Cy.r)), //  t_ry = sy-c*ry
-    //t_rz = Az.r.sub(cc.mul(Cz.r)), //  t_rz = sz-c*rz
-    t_r4 = kz.sub(cc.mul(Cz.r.sub(Cx.r.mul(yy)))) //  t_r4 = s4-c*r4
+        /*C4 = Cy.p.mul(xx), // C4 = Cy * x
+        r4 = Cy.r.mul(xx), // C4 = zG + r4H*/
+        // Step 1: Compute commitments
+        k_x = rnd(params.c.order),
+        k_y = rnd(params.c.order),
+        k_z = rnd(params.c.order),
+        ky = params.c.newScalar(k_y),
+        kz = params.c.newScalar(k_z),
+        Ax = params.commit(k_x),
+        Ay = params.commit(k_y),
+        //Az = params.commit(k_z),
+        //A4_1 = params.commit(k_z),
+        A4_2 = (Cx.p.mul(ky)).add(params.h.mul(kz)),
+        // Step 2: Compute challenge  H(Cx, Cy, Cz, C4, Ax, Ay, Az, A4_1, A4_2)
+        c = await hashPoints('SHA-256', [Cx.p, Cy.p, Cz.p, Ax.p, Ay.p, A4_2]),
+        cc = params.c.newScalar(c),
+        kx = params.c.newScalar(k_x),
+        //kz = params.c.newScalar(k_z),
+        yy = params.c.newScalar(y),
+        //zz = params.c.newScalar(z),
+        t_x = kx.sub(cc.mul(xx)), // tx = kx-c*x
+        t_y = ky.sub(cc.mul(yy)), // ty = ky-c*y
+        //t_z = kz.sub(cc.mul(zz)), // tz = kz-c*z
+        t_rx = Ax.r.sub(cc.mul(Cx.r)), //  t_rx = sx-c*rx
+        t_ry = Ay.r.sub(cc.mul(Cy.r)), //  t_ry = sy-c*ry
+        //t_rz = Az.r.sub(cc.mul(Cz.r)), //  t_rz = sz-c*rz
+        t_r4 = kz.sub(cc.mul(Cz.r.sub(Cx.r.mul(yy)))) //  t_r4 = s4-c*r4
 
     return new MultProof(Ax.p, Ay.p, A4_2, t_x, t_y, t_rx, t_ry, t_r4)
 }

--- a/src/commit/mult.ts
+++ b/src/commit/mult.ts
@@ -24,63 +24,63 @@ import { rnd } from '../bignum/big.js'
 @jsonObject
 @toJson
 export class MultProof {
-    @jsonMember({ constructor: Group.Point, isRequired: true }) C_4: Group.Point
+    //@jsonMember({ constructor: Group.Point, isRequired: true }) C_4: Group.Point
     @jsonMember({ constructor: Group.Point, isRequired: true }) A_x: Group.Point
     @jsonMember({ constructor: Group.Point, isRequired: true }) A_y: Group.Point
-    @jsonMember({ constructor: Group.Point, isRequired: true }) A_z: Group.Point
-    @jsonMember({ constructor: Group.Point, isRequired: true }) A_4_1: Group.Point
+    //@jsonMember({ constructor: Group.Point, isRequired: true }) A_z: Group.Point
+    //@jsonMember({ constructor: Group.Point, isRequired: true }) A_4_1: Group.Point
     @jsonMember({ constructor: Group.Point, isRequired: true }) A_4_2: Group.Point
     @jsonMember({ constructor: Group.Scalar, isRequired: true }) t_x: Group.Scalar
     @jsonMember({ constructor: Group.Scalar, isRequired: true }) t_y: Group.Scalar
-    @jsonMember({ constructor: Group.Scalar, isRequired: true }) t_z: Group.Scalar
+    //@jsonMember({ constructor: Group.Scalar, isRequired: true }) t_z: Group.Scalar
     @jsonMember({ constructor: Group.Scalar, isRequired: true }) t_rx: Group.Scalar
     @jsonMember({ constructor: Group.Scalar, isRequired: true }) t_ry: Group.Scalar
-    @jsonMember({ constructor: Group.Scalar, isRequired: true }) t_rz: Group.Scalar
+    //@jsonMember({ constructor: Group.Scalar, isRequired: true }) t_rz: Group.Scalar
     @jsonMember({ constructor: Group.Scalar, isRequired: true }) t_r4: Group.Scalar
 
     constructor(
-        C_4: Group.Point,
+        //C_4: Group.Point,
         A_x: Group.Point,
         A_y: Group.Point,
-        A_z: Group.Point,
-        A_4_1: Group.Point,
+        //A_z: Group.Point,
+        //A_4_1: Group.Point,
         A_4_2: Group.Point,
         t_x: Group.Scalar,
         t_y: Group.Scalar,
-        t_z: Group.Scalar,
+        //t_z: Group.Scalar,
         t_rx: Group.Scalar,
         t_ry: Group.Scalar,
-        t_rz: Group.Scalar,
+        //t_rz: Group.Scalar,
         t_r4: Group.Scalar
     ) {
-        this.C_4 = C_4
+        //this.C_4 = C_4
         this.A_x = A_x
         this.A_y = A_y
-        this.A_z = A_z
-        this.A_4_1 = A_4_1
+        //this.A_z = A_z
+        //this.A_4_1 = A_4_1
         this.A_4_2 = A_4_2
         this.t_x = t_x
         this.t_y = t_y
-        this.t_z = t_z
+        //this.t_z = t_z
         this.t_rx = t_rx
         this.t_ry = t_ry
-        this.t_rz = t_rz
+        //this.t_rz = t_rz
         this.t_r4 = t_r4
     }
     eq(o: MultProof): boolean {
         return (
-            this.C_4.eq(o.C_4) &&
+            //this.C_4.eq(o.C_4) &&
             this.A_x.eq(o.A_x) &&
             this.A_y.eq(o.A_y) &&
-            this.A_z.eq(o.A_z) &&
-            this.A_4_1.eq(o.A_4_1) &&
+            //this.A_z.eq(o.A_z) &&
+            //this.A_4_1.eq(o.A_4_1) &&
             this.A_4_2.eq(o.A_4_2) &&
             this.t_x.eq(o.t_x) &&
             this.t_y.eq(o.t_y) &&
-            this.t_z.eq(o.t_z) &&
+            //this.t_z.eq(o.t_z) &&
             this.t_rx.eq(o.t_rx) &&
             this.t_ry.eq(o.t_ry) &&
-            this.t_rz.eq(o.t_rz) &&
+            //this.t_rz.eq(o.t_rz) &&
             this.t_r4.eq(o.t_r4)
         )
     }
@@ -100,34 +100,35 @@ export async function proveMult(
     Cz: Commitment
 ): Promise<MultProof> {
     const xx = params.c.newScalar(x),
-        C4 = Cy.p.mul(xx), // C4 = Cy * x
-        r4 = Cy.r.mul(xx), // C4 = zG + r4H
-        // Step 1: Compute commitments
-        k_x = rnd(params.c.order),
-        k_y = rnd(params.c.order),
-        k_z = rnd(params.c.order),
-        kx = params.c.newScalar(k_x),
-        Ax = params.commit(k_x),
-        Ay = params.commit(k_y),
-        Az = params.commit(k_z),
-        A4_1 = params.commit(k_z),
-        A4_2 = Cy.p.mul(kx),
-        // Step 2: Compute challenge  H(Cx, Cy, Cz, C4, Ax, Ay, Az, A4_1, A4_2)
-        c = await hashPoints('SHA-256', [Cx.p, Cy.p, Cz.p, C4, Ax.p, Ay.p, Az.p, A4_1.p, A4_2]),
-        cc = params.c.newScalar(c),
-        ky = params.c.newScalar(k_y),
-        kz = params.c.newScalar(k_z),
-        yy = params.c.newScalar(y),
-        zz = params.c.newScalar(z),
-        t_x = kx.sub(cc.mul(xx)), // tx = kx-c*x
-        t_y = ky.sub(cc.mul(yy)), // ty = ky-c*y
-        t_z = kz.sub(cc.mul(zz)), // tz = kz-c*z
-        t_rx = Ax.r.sub(cc.mul(Cx.r)), //  t_rx = sx-c*rx
-        t_ry = Ay.r.sub(cc.mul(Cy.r)), //  t_ry = sy-c*ry
-        t_rz = Az.r.sub(cc.mul(Cz.r)), //  t_rz = sz-c*rz
-        t_r4 = A4_1.r.sub(cc.mul(r4)) //  t_r4 = s4-c*r4
+    /*C4 = Cy.p.mul(xx), // C4 = Cy * x
+    r4 = Cy.r.mul(xx), // C4 = zG + r4H*/
+    // Step 1: Compute commitments
+    k_x = rnd(params.c.order),
+    k_y = rnd(params.c.order),
+    k_z = rnd(params.c.order),
+    ky = params.c.newScalar(k_y),
+    kz = params.c.newScalar(k_z),
+    Ax = params.commit(k_x),
+    Ay = params.commit(k_y),
+    //Az = params.commit(k_z),
+    //A4_1 = params.commit(k_z),
+    A4_2 = (Cx.p.mul(ky)).add(params.h.mul(kz)),
+    // Step 2: Compute challenge  H(Cx, Cy, Cz, C4, Ax, Ay, Az, A4_1, A4_2)
+    c = await hashPoints('SHA-256', [Cx.p, Cy.p, Cz.p, Ax.p, Ay.p, A4_2]),
+    cc = params.c.newScalar(c),
+    kx = params.c.newScalar(k_x),
+    //kz = params.c.newScalar(k_z),
+    yy = params.c.newScalar(y),
+    //zz = params.c.newScalar(z),
+    t_x = kx.sub(cc.mul(xx)), // tx = kx-c*x
+    t_y = ky.sub(cc.mul(yy)), // ty = ky-c*y
+    //t_z = kz.sub(cc.mul(zz)), // tz = kz-c*z
+    t_rx = Ax.r.sub(cc.mul(Cx.r)), //  t_rx = sx-c*rx
+    t_ry = Ay.r.sub(cc.mul(Cy.r)), //  t_ry = sy-c*ry
+    //t_rz = Az.r.sub(cc.mul(Cz.r)), //  t_rz = sz-c*rz
+    t_r4 = kz.sub(cc.mul(Cz.r.sub(Cx.r.mul(yy)))) //  t_r4 = s4-c*r4
 
-    return new MultProof(C4, Ax.p, Ay.p, Az.p, A4_1.p, A4_2, t_x, t_y, t_z, t_rx, t_ry, t_rz, t_r4)
+    return new MultProof(Ax.p, Ay.p, A4_2, t_x, t_y, t_rx, t_ry, t_r4)
 }
 
 export async function verifyMult(
@@ -153,23 +154,17 @@ export async function aggregateMult(
     pi: MultProof,
     multi: MultiMult
 ): Promise<boolean> {
-    const challenge = await hashPoints('SHA-256', [Cx, Cy, Cz, pi.C_4, pi.A_x, pi.A_y, pi.A_z, pi.A_4_1, pi.A_4_2]),
-        cc = params.c.newScalar(challenge),
-        A_xrel = new Relation(params.c)
+    const challenge = await hashPoints('SHA-256', [Cx, Cy, Cz, pi.A_x, pi.A_y, pi.A_4_2]),
+    cc = params.c.newScalar(challenge),
+    A_xrel = new Relation(params.c)
     A_xrel.insertM([params.g, params.h, Cx, pi.A_x.neg()], [pi.t_x, pi.t_rx, cc, params.c.newScalar(BigInt(1))])
     const A_yrel = new Relation(params.c)
     A_yrel.insertM([params.g, params.h, Cy, pi.A_y.neg()], [pi.t_y, pi.t_ry, cc, params.c.newScalar(BigInt(1))])
-    const A_zrel = new Relation(params.c)
-    A_zrel.insertM([params.g, params.h, Cz, pi.A_z.neg()], [pi.t_z, pi.t_rz, cc, params.c.newScalar(BigInt(1))])
-    const A_4_1rel = new Relation(params.c)
-    A_4_1rel.insertM([params.g, params.h, pi.C_4, pi.A_4_1.neg()], [pi.t_z, pi.t_r4, cc, params.c.newScalar(BigInt(1))])
     const A_4_2rel = new Relation(params.c)
-    A_4_2rel.insertM([Cy, pi.C_4, pi.A_4_2.neg()], [pi.t_x, cc, params.c.newScalar(BigInt(1))])
+    A_4_2rel.insertM([Cx, params.h, Cz.neg(), pi.A_4_2.neg()], [pi.t_y, pi.t_r4, cc, params.c.newScalar(BigInt(1))])
 
     A_xrel.drain(multi)
     A_yrel.drain(multi)
-    A_zrel.drain(multi)
-    A_4_1rel.drain(multi)
     A_4_2rel.drain(multi)
     return true
 }

--- a/src/exp/pointAdd.ts
+++ b/src/exp/pointAdd.ts
@@ -123,6 +123,9 @@ export async function provePointAdd(
     if (!coordR) {
         throw new Error('R is at infinity')
     }
+    if (P.eq(Q)) {
+        throw new Error('P should not be equal with Q')
+    }
     const { x: x1, y: y1 } = coordP,
         { x: x2, y: y2 } = coordQ,
         { x: x3 } = coordR, // todo(question): why y3 is not used?

--- a/test/exp/pointAdd.test.ts
+++ b/test/exp/pointAdd.test.ts
@@ -36,6 +36,9 @@ export async function testPointAdd(): Promise<boolean> {
     if (!coordP3) {
         throw new Error('P3 is at infinity')
     }
+    if (P1.eq(P2)) {
+        throw new Error('P1 should not be equal with P2')
+    }
     const { x: x1, y: y1 } = coordP1,
         { x: x2, y: y2 } = coordP2,
         { x: x3, y: y3 } = coordP3,


### PR DESCRIPTION
1) Change multiplication proof: the algorithm in [Doubly-efficient zkSNARKs without trusted setup](https://eprint.iacr.org/2017/1132.pdf) Figure 5 is more efficient. 
2) For the realization of point addition proof in this repo, `P!=Q` constraint should be added.  